### PR TITLE
Implemented simple print methods.

### DIFF
--- a/R/direction.R
+++ b/R/direction.R
@@ -94,6 +94,8 @@ after <- function(start_event, within_given = NULL){
 
   class(out) <- "schedule"
 
+  out$n_terms <- 1
+
   out
 }
 
@@ -143,6 +145,8 @@ before <- function(end_event, within_given = NULL){
   out <- list(date_test = date_test)
 
   class(out) <- "schedule"
+
+  out$n_terms <- 1
 
   out
 }

--- a/R/doesnt.R
+++ b/R/doesnt.R
@@ -57,6 +57,8 @@ doesnt_occur <- function(x, y = NULL){
 
     class(out) <- c("schedule")
 
+    out$n_terms <- 2
+
     out
 
   } else {
@@ -68,6 +70,8 @@ doesnt_occur <- function(x, y = NULL){
     out <- list(date_test = date_test)
 
     class(out) <- c("schedule")
+
+    out$n_terms <- 1
 
     x %>% only_occur(out)
   }

--- a/R/make.R
+++ b/R/make.R
@@ -8,5 +8,7 @@ make_element <- function(x, .f, ...){
 
   class(out) <- "schedule"
 
+  out$n_terms <- 1
+
   out
 }

--- a/R/nth.R
+++ b/R/nth.R
@@ -115,6 +115,8 @@ on_nth <- function(n, x, within_given){
 
   class(out) <- "schedule"
 
+  out$n_terms <- 1
+
   out
 }
 

--- a/R/print.R
+++ b/R/print.R
@@ -1,0 +1,5 @@
+print.schedule <- function(x){
+  cat("A schedule of events containing ")
+  cat(x$n_terms)
+  cat(" term(s)")
+}

--- a/R/sets.R
+++ b/R/sets.R
@@ -59,6 +59,8 @@ also_occur <- function(x, y){
 
   class(out) <- "schedule"
 
+  out$n_terms <- x$n_terms + y$n_terms
+
   out
 
 }
@@ -80,6 +82,8 @@ only_occur <- function(x, y){
   out <- list(date_test = date_test)
 
   class(out) <- "schedule"
+
+  out$n_terms <- x$n_terms + y$n_terms
 
   if("latest_date" %in% get_attribute_names(x)){
     attr(out, "latest_date") <- attr(x, "latest_date")

--- a/docs/articles/intro.html
+++ b/docs/articles/intro.html
@@ -92,7 +92,7 @@
       <h1>Work with recurring calendar events in R</h1>
                         <h4 class="author">James Laird-Smith</h4>
             
-            <h4 class="date">2019-08-30</h4>
+            <h4 class="date">2019-08-31</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/jameslairdsmith/gs/blob/master/vignettes/intro.Rmd"><code>vignettes/intro.Rmd</code></a></small>
       <div class="hidden name"><code>intro.Rmd</code></div>
@@ -121,8 +121,8 @@
 <a class="sourceLine" id="cb3-3" data-line-number="3"><span class="co">#&gt; {</span></a>
 <a class="sourceLine" id="cb3-4" data-line-number="4"><span class="co">#&gt;     .f(date, ...) == x</span></a>
 <a class="sourceLine" id="cb3-5" data-line-number="5"><span class="co">#&gt; }</span></a>
-<a class="sourceLine" id="cb3-6" data-line-number="6"><span class="co">#&gt; &lt;bytecode: 0x7f90ca7d6b20&gt;</span></a>
-<a class="sourceLine" id="cb3-7" data-line-number="7"><span class="co">#&gt; &lt;environment: 0x7f90ca7da480&gt;</span></a>
+<a class="sourceLine" id="cb3-6" data-line-number="6"><span class="co">#&gt; &lt;bytecode: 0x7fa22f6a4f90&gt;</span></a>
+<a class="sourceLine" id="cb3-7" data-line-number="7"><span class="co">#&gt; &lt;environment: 0x7fa22f6a88f0&gt;</span></a>
 <a class="sourceLine" id="cb3-8" data-line-number="8"><span class="co">#&gt; attr(,"class")</span></a>
 <a class="sourceLine" id="cb3-9" data-line-number="9"><span class="co">#&gt; [1] "schedule"</span></a></code></pre></div>
 <p>By itself, this isn’t that useful. What will help make it more so is that we can make this schedule an object like so:</p>


### PR DESCRIPTION
Schedules should have print methods that are helpful to the user for understanding what they are. The problem is that schedules can be complex and coming up with a print method that is flexible enough to describe an arbitrarily complex schedule is difficult. This pull request implements a simple print method which is good enough for the moment.